### PR TITLE
feat: add basic FVM with AST translation and REPL

### DIFF
--- a/src/main/java/org/foolish/fvm/ASTToFVM.java
+++ b/src/main/java/org/foolish/fvm/ASTToFVM.java
@@ -57,8 +57,10 @@ public class ASTToFVM {
                 elseIfs.add((IfExpr) translate(e));
             }
             return new IfExpr(cond, thenExpr, elseExpr, elseIfs);
+        } else if (expr instanceof AST.UnknownExpr) {
+            throw new IllegalArgumentException("Unknown expression encountered");
         }
-        return new IntegerLiteral(0); // Unknown expression
+        throw new IllegalArgumentException("Unsupported AST expression: " + expr.getClass().getSimpleName());
     }
 
     private Characterizable toCharacterizable(AST.Identifier id) {

--- a/src/main/java/org/foolish/fvm/Environment.java
+++ b/src/main/java/org/foolish/fvm/Environment.java
@@ -2,7 +2,6 @@ package org.foolish.fvm;
 
 import java.util.HashMap;
 import java.util.Map;
-import java.util.Optional;
 
 /**
  * An environment that holds identifier bindings.  Environments may be nested
@@ -22,7 +21,7 @@ public class Environment {
     }
 
     public void define(Characterizable id, Object value) {
-        values.put(id, value);
+        values.put(id, value == null ? Unknown.INSTANCE : value);
     }
 
     public boolean contains(Characterizable id) {
@@ -30,13 +29,14 @@ public class Environment {
         return parent != null && parent.contains(id);
     }
 
-    public Optional<Object> lookup(Characterizable id) {
+    public Object lookup(Characterizable id) {
         if (values.containsKey(id)) {
-            return Optional.ofNullable(values.get(id));
+            Object v = values.get(id);
+            return v == null ? Unknown.INSTANCE : v;
         }
         if (parent != null) {
             return parent.lookup(id);
         }
-        return Optional.empty();
+        return Unknown.INSTANCE;
     }
 }

--- a/src/main/java/org/foolish/fvm/IdentifierExpr.java
+++ b/src/main/java/org/foolish/fvm/IdentifierExpr.java
@@ -1,7 +1,5 @@
 package org.foolish.fvm;
 
-import java.util.Optional;
-
 /**
  * Resolves the value of an identifier from the environment.
  */
@@ -16,7 +14,6 @@ public class IdentifierExpr implements Instruction {
 
     @Override
     public Object execute(Environment env) {
-        Optional<Object> value = env.lookup(id);
-        return value.orElse(null);
+        return env.lookup(id);
     }
 }

--- a/src/main/java/org/foolish/fvm/Unknown.java
+++ b/src/main/java/org/foolish/fvm/Unknown.java
@@ -1,0 +1,15 @@
+package org.foolish.fvm;
+
+/**
+ * Sentinel value representing an unknown result in the FVM.
+ */
+public final class Unknown {
+    public static final Unknown INSTANCE = new Unknown();
+
+    private Unknown() {}
+
+    @Override
+    public String toString() {
+        return "???";
+    }
+}

--- a/src/test/java/org/foolish/fvm/BraneTest.java
+++ b/src/test/java/org/foolish/fvm/BraneTest.java
@@ -17,7 +17,7 @@ public class BraneTest {
         Environment env = new Environment();
         Object result = brane.execute(env);
         assertEquals(42L, result);
-        assertEquals(42L, env.lookup(x).orElse(null));
+        assertEquals(42L, env.lookup(x));
     }
 
     @Test
@@ -28,6 +28,6 @@ public class BraneTest {
         Branes branes = new Branes(List.of(b1, b2));
         Environment env = new Environment();
         branes.execute(env);
-        assertEquals(2L, env.lookup(x).orElse(null));
+        assertEquals(2L, env.lookup(x));
     }
 }

--- a/src/test/java/org/foolish/fvm/EnvironmentTest.java
+++ b/src/test/java/org/foolish/fvm/EnvironmentTest.java
@@ -11,10 +11,10 @@ public class EnvironmentTest {
         parent.define(x, 1L);
 
         Environment child = new Environment(parent);
-        assertEquals(1L, child.lookup(x).orElse(null));
+        assertEquals(1L, child.lookup(x));
 
         child.define(x, 2L);
-        assertEquals(2L, child.lookup(x).orElse(null));
-        assertEquals(1L, parent.lookup(x).orElse(null));
+        assertEquals(2L, child.lookup(x));
+        assertEquals(1L, parent.lookup(x));
     }
 }


### PR DESCRIPTION
## Summary
- throw errors for unsupported or unknown AST nodes
- represent absent values with an explicit UNKNOWN sentinel in the environment

## Testing
- `mvn -q -e -Dantlr4.skip=true test` *(fails: Plugin org.antlr:antlr4-maven-plugin:4.13.2 or one of its dependencies could not be resolved: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68bcbd1374bc8323823de3101ed01799