### PR TITLE
Add CI workflow to run Maven tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,20 @@
+name: Java CI
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+    branches: ["main"]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: '21'
+          cache: 'maven'
+      - name: Run tests
+        run: mvn -B test


### PR DESCRIPTION
## Summary
- run `mvn test` on pushes and pull requests

## Testing
- `mvn -q test` *(fails: Plugin org.antlr:antlr4-maven-plugin 4.13.2 could not be resolved: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68bf13a24cc483239f55d15f8c99c330