### PR TITLE
Refactor FVM with Targoe/Resoe model and copy-on-write env

### DIFF
--- a/src/main/java/org/foolish/fvm/EvalResult.java
+++ b/src/main/java/org/foolish/fvm/EvalResult.java
@@ -1,0 +1,8 @@
+package org.foolish.fvm;
+
+/**
+ * Container holding both the result of evaluating a {@link Targoe} and the
+ * resulting environment. The environment is provided so that copy-on-write
+ * semantics can propagate updated environments to subsequent evaluations.
+ */
+public record EvalResult(Resoe value, Environment env) {}

--- a/src/main/java/org/foolish/fvm/Targoe.java
+++ b/src/main/java/org/foolish/fvm/Targoe.java
@@ -39,10 +39,3 @@ public abstract class Targoe {
     public abstract EvalResult execute(Environment env);
 }
 
-/**
- * Container holding both the result of evaluating a {@link Targoe} and the
- * resulting environment.  The environment is provided so that copy-on-write
- * semantics can propagate updated environments to subsequent evaluations.
- */
-public record EvalResult(Resoe value, Environment env) {}
-


### PR DESCRIPTION
## Summary
- move `EvalResult` record into its own file so `Targoe.java` has a single public top-level type

## Testing
- `mvn -q -e test` *(fails: Plugin org.antlr:antlr4-maven-plugin:4.13.2 or one of its dependencies could not be resolved: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68c0710d425883238fdcfffbae1ebdc6